### PR TITLE
[BUGFIX] Ensure that Rulerefs n-levels deep are expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
+  * Bugfix: Rulerefs referenced n-levels deep under Rulerefs should be expanded.
 
 # [2.3.2](https://github.com/benlangfeld/ruby_speech/compare/v2.3.1...v2.3.2) - [2014-04-21](https://rubygems.org/gems/ruby_speech/versions/2.3.2)
   * Bugfix: String nodes should take non-strings and cast to a string (`#to_s`)

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -116,9 +116,13 @@ module RubySpeech
       # @return self
       #
       def inline!
-        xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
-          rule = rule_with_id ref[:uri].sub(/^#/, '')
-          ref.swap rule.dup.children
+        loop do
+          rule = nil
+          xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
+            rule = rule_with_id ref[:uri].sub(/^#/, '')
+            ref.swap rule.dup.children
+          end
+          break unless rule
         end
 
         query = "./ns:rule[@id!='#{root}']"

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -120,6 +120,7 @@ module RubySpeech
           rule = nil
           xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
             rule = rule_with_id ref[:uri].sub(/^#/, '')
+            raise ArgumentError, "The Ruleref \"#{ref[:uri]}\" is referenced but not defined" unless rule
             ref.swap rule.dup.children
           end
           break unless rule

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -32,7 +32,7 @@ module RubySpeech
       self.defaults = { :version => '1.0', :language => "en-US", namespace: GRXML_NAMESPACE }
 
       VALID_CHILD_TYPES = [Nokogiri::XML::Element, Nokogiri::XML::Text, Rule, Tag].freeze
-      MAX_RULE_NESTING_DEFAULT = 25.freeze
+      MAX_RULE_NESTING_DEFAULT = 25
 
       ##
       #

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -120,7 +120,7 @@ module RubySpeech
         (self.class.max_rule_nesting + 1).times do |i|
           rule = nil
           j = 0
-          xpath("//ns:ruleref", :ns => GRXML_NAMESPACE).each do |ref|
+          xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
             if ([i,j].max + 1) > self.class.max_rule_nesting
               raise ArgumentError, "Max ruleref recursion level of #{self.class.max_rule_nesting} has been exceeded."
             end

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -121,7 +121,7 @@ module RubySpeech
           rule = nil
           j = 0
           xpath("//ns:ruleref", ns: GRXML_NAMESPACE).each do |ref|
-            if ([i,j].max + 1) > self.class.max_rule_nesting
+            if ([i, j].max + 1) > self.class.max_rule_nesting
               raise ArgumentError, "Max ruleref recursion level of #{self.class.max_rule_nesting} has been exceeded."
             end
             rule = rule_with_id ref[:uri].sub(/^#/, "")

--- a/lib/ruby_speech/grxml/grammar.rb
+++ b/lib/ruby_speech/grxml/grammar.rb
@@ -124,7 +124,7 @@ module RubySpeech
             if ([i,j].max + 1) > self.class.max_rule_nesting
               raise ArgumentError, "Max ruleref recursion level of #{self.class.max_rule_nesting} has been exceeded."
             end
-            rule = rule_with_id ref[:uri].sub(/^#/, '')
+            rule = rule_with_id ref[:uri].sub(/^#/, "")
             raise ArgumentError, "The Ruleref \"#{ref[:uri]}\" is referenced but not defined" unless rule
             ref.swap rule.dup.children
             j += 1
@@ -197,7 +197,7 @@ module RubySpeech
       private
 
       def self.max_rule_nesting
-        (ENV['RUBYSPEECH_MAX_RULE_NESTING'] || MAX_RULE_NESTING_DEFAULT).to_i
+        (ENV["RUBYSPEECH_MAX_RULE_NESTING"] || MAX_RULE_NESTING_DEFAULT).to_i
       end
 
       def has_matching_root_rule?

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -310,6 +310,20 @@ module RubySpeech
 
             pending 'should raise an Exception'
           end
+
+          context 'with an invalid-reference' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#lost'
+                end
+              end.inline
+            end
+
+            it 'should raise a descriptive exception' do
+              expect { subject }.to raise_error ArgumentError, 'The Ruleref "#lost" is referenced but not defined'
+            end
+          end
         end
       end
 

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -232,6 +232,70 @@ module RubySpeech
           grammar.inline!.should == inline_grammar
           grammar.should == inline_grammar
         end
+
+        context 'nested' do
+          let :expected_doc do
+            RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+              rule :id => :main, :scope => 'public' do
+                string "How about an oatmeal cookie?  You'll feel better."
+              end
+            end
+          end
+
+          context '1 level deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+
+          context '2 levels deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
+                end
+                rule id: 'rabbit_hole3' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+
+          context '3 levels deep' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#rabbit_hole2'
+                end
+                rule id: 'rabbit_hole2' do
+                  ruleref uri: '#rabbit_hole3'
+                end
+                rule id: 'rabbit_hole3' do
+                  ruleref uri: '#rabbit_hole4'
+                end
+                rule id: 'rabbit_hole4' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end.inline
+            end
+
+            it { should eq expected_doc }
+          end
+        end
       end
 
       describe "#tokenize!" do

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -295,6 +295,21 @@ module RubySpeech
 
             it { should eq expected_doc }
           end
+
+          context 'in a self-referencial infinite loop' do
+            subject do
+              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  ruleref uri: '#paradox'
+                end
+                rule id: 'paradox' do
+                  ruleref uri: '#paradox'
+                end
+              end.inline
+            end
+
+            pending 'should raise an Exception'
+          end
         end
       end
 

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -234,68 +234,6 @@ module RubySpeech
         end
 
         context 'nested' do
-          let :expected_doc do
-            RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-              rule :id => :main, :scope => 'public' do
-                string "How about an oatmeal cookie?  You'll feel better."
-              end
-            end
-          end
-
-          context '1 level deep' do
-            subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
-                end
-                rule id: 'rabbit_hole2' do
-                  string "How about an oatmeal cookie?  You'll feel better."
-                end
-              end.inline
-            end
-
-            it { should eq expected_doc }
-          end
-
-          context '2 levels deep' do
-            subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
-                end
-                rule id: 'rabbit_hole2' do
-                  ruleref uri: '#rabbit_hole3'
-                end
-                rule id: 'rabbit_hole3' do
-                  string "How about an oatmeal cookie?  You'll feel better."
-                end
-              end.inline
-            end
-
-            it { should eq expected_doc }
-          end
-
-          context '3 levels deep' do
-            subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
-                  ruleref uri: '#rabbit_hole2'
-                end
-                rule id: 'rabbit_hole2' do
-                  ruleref uri: '#rabbit_hole3'
-                end
-                rule id: 'rabbit_hole3' do
-                  ruleref uri: '#rabbit_hole4'
-                end
-                rule id: 'rabbit_hole4' do
-                  string "How about an oatmeal cookie?  You'll feel better."
-                end
-              end.inline
-            end
-
-            it { should eq expected_doc }
-          end
-
           context 'in a self-referencial infinite loop' do
             subject do
               RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
@@ -305,10 +243,12 @@ module RubySpeech
                 rule id: 'paradox' do
                   ruleref uri: '#paradox'
                 end
-              end.inline
+              end
             end
 
-            pending 'should raise an Exception'
+            it 'should be rejected with an error' do
+              expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 25 has been exceeded./
+            end
           end
 
           context 'with an invalid-reference' do
@@ -322,6 +262,78 @@ module RubySpeech
 
             it 'should raise a descriptive exception' do
               expect { subject }.to raise_error ArgumentError, 'The Ruleref "#lost" is referenced but not defined'
+            end
+          end
+
+          context 'deeply' do
+            before :each do
+              subject.root = 'main'
+              subject << Rule.new(doc, :id => 'main', :scope => 'public') do
+                ruleref uri: '#level0'
+              end
+
+              levels.times do |i|
+                next_ref = i + 1
+                subject << if next_ref < levels
+                   Rule.new(doc, :id => "level#{i}") do
+                    ruleref uri: "#level#{next_ref}"
+                  end
+                else
+                  Rule.new(doc, :id => "level#{i}") do
+                    string "How about an oatmeal cookie?  You'll feel better."
+                  end
+                end
+              end
+            end
+
+            after :each do
+              ENV['RUBYSPEECH_MAX_RULE_NESTING'] = nil
+            end
+
+            let :expected_doc do
+              RubySpeech::GRXML.draw root: 'main' do
+                rule :id => :main, :scope => 'public' do
+                  string "How about an oatmeal cookie?  You'll feel better."
+                end
+              end
+            end
+
+            context '25 levels deep' do
+              let(:levels) { 25 }
+
+              it 'should equal the expected doc' do
+                expect(subject.inline).to eq expected_doc
+              end
+            end
+
+            context '26 levels deep' do
+              let(:levels) { 26 }
+
+              it 'should be rejected with an error' do
+                expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 25 has been exceeded./
+              end
+            end
+
+            context 'with RUBYSPEECH_MAX_RULE_NESTING=100' do
+              before :each do
+                ENV['RUBYSPEECH_MAX_RULE_NESTING'] = '100'
+              end
+
+              context '100 levels deep' do
+                let(:levels) { 100 }
+
+                it 'should equal the expected doc' do
+                  expect(subject.inline).to eq expected_doc
+                end
+              end
+
+              context '101 levels deep' do
+                let(:levels) { 101 }
+
+                it 'should be rejected with an error' do
+                  expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 100 has been exceeded./
+                end
+              end
             end
           end
         end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -233,43 +233,43 @@ module RubySpeech
           grammar.should == inline_grammar
         end
 
-        context 'nested' do
-          context 'in a self-referencial infinite loop' do
+        context "nested" do
+          context "in a self-referencial infinite loop" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule id: :main, scope: 'public' do
-                  ruleref uri: '#paradox'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#paradox"
                 end
-                rule id: 'paradox' do
-                  ruleref uri: '#paradox'
+                rule id: "paradox" do
+                  ruleref uri: "#paradox"
                 end
               end
             end
 
-            it 'should be rejected with an error' do
+            it "should be rejected with an error" do
               expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 25 has been exceeded./
             end
           end
 
-          context 'with an invalid-reference' do
+          context "with an invalid-reference" do
             subject do
-              RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule id: :main, scope: 'public' do
-                  ruleref uri: '#lost'
+              RubySpeech::GRXML.draw mode: :dtmf, root: "main" do
+                rule id: :main, scope: "public" do
+                  ruleref uri: "#lost"
                 end
               end.inline
             end
 
-            it 'should raise a descriptive exception' do
+            it "should raise a descriptive exception" do
               expect { subject }.to raise_error ArgumentError, 'The Ruleref "#lost" is referenced but not defined'
             end
           end
 
-          context 'deeply' do
+          context "deeply" do
             before :each do
-              subject.root = 'main'
-              subject << Rule.new(doc, id: 'main', scope: 'public') do
-                ruleref uri: '#level0'
+              subject.root = "main"
+              subject << Rule.new(doc, id: "main", scope: "public") do
+                ruleref uri: "#level0"
               end
 
               levels.times do |i|
@@ -287,50 +287,50 @@ module RubySpeech
             end
 
             after :each do
-              ENV['RUBYSPEECH_MAX_RULE_NESTING'] = nil
+              ENV["RUBYSPEECH_MAX_RULE_NESTING"] = nil
             end
 
             let :expected_doc do
-              RubySpeech::GRXML.draw root: 'main' do
-                rule id: :main, scope: 'public' do
+              RubySpeech::GRXML.draw root: "main" do
+                rule id: :main, scope: "public" do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end
             end
 
-            context '25 levels deep' do
+            context "25 levels deep" do
               let(:levels) { 25 }
 
-              it 'should equal the expected doc' do
+              it "should equal the expected doc" do
                 expect(subject.inline).to eq expected_doc
               end
             end
 
-            context '26 levels deep' do
+            context "26 levels deep" do
               let(:levels) { 26 }
 
-              it 'should be rejected with an error' do
+              it "should be rejected with an error" do
                 expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 25 has been exceeded./
               end
             end
 
-            context 'with RUBYSPEECH_MAX_RULE_NESTING=100' do
+            context "with RUBYSPEECH_MAX_RULE_NESTING=100" do
               before :each do
-                ENV['RUBYSPEECH_MAX_RULE_NESTING'] = '100'
+                ENV["RUBYSPEECH_MAX_RULE_NESTING"] = "100"
               end
 
-              context '100 levels deep' do
+              context "100 levels deep" do
                 let(:levels) { 100 }
 
-                it 'should equal the expected doc' do
+                it "should equal the expected doc" do
                   expect(subject.inline).to eq expected_doc
                 end
               end
 
-              context '101 levels deep' do
+              context "101 levels deep" do
                 let(:levels) { 101 }
 
-                it 'should be rejected with an error' do
+                it "should be rejected with an error" do
                   expect { subject.inline }.to raise_error ArgumentError, /Max ruleref recursion level of 100 has been exceeded./
                 end
               end

--- a/spec/ruby_speech/grxml/grammar_spec.rb
+++ b/spec/ruby_speech/grxml/grammar_spec.rb
@@ -237,7 +237,7 @@ module RubySpeech
           context 'in a self-referencial infinite loop' do
             subject do
               RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
+                rule id: :main, scope: 'public' do
                   ruleref uri: '#paradox'
                 end
                 rule id: 'paradox' do
@@ -254,7 +254,7 @@ module RubySpeech
           context 'with an invalid-reference' do
             subject do
               RubySpeech::GRXML.draw mode: :dtmf, root: 'main' do
-                rule :id => :main, :scope => 'public' do
+                rule id: :main, scope: 'public' do
                   ruleref uri: '#lost'
                 end
               end.inline
@@ -268,18 +268,18 @@ module RubySpeech
           context 'deeply' do
             before :each do
               subject.root = 'main'
-              subject << Rule.new(doc, :id => 'main', :scope => 'public') do
+              subject << Rule.new(doc, id: 'main', scope: 'public') do
                 ruleref uri: '#level0'
               end
 
               levels.times do |i|
                 next_ref = i + 1
                 subject << if next_ref < levels
-                   Rule.new(doc, :id => "level#{i}") do
+                   Rule.new(doc, id: "level#{i}") do
                     ruleref uri: "#level#{next_ref}"
                   end
                 else
-                  Rule.new(doc, :id => "level#{i}") do
+                  Rule.new(doc, id: "level#{i}") do
                     string "How about an oatmeal cookie?  You'll feel better."
                   end
                 end
@@ -292,7 +292,7 @@ module RubySpeech
 
             let :expected_doc do
               RubySpeech::GRXML.draw root: 'main' do
-                rule :id => :main, :scope => 'public' do
+                rule id: :main, scope: 'public' do
                   string "How about an oatmeal cookie?  You'll feel better."
                 end
               end


### PR DESCRIPTION
When grammars are interpreted _inline_ by RubySpeech itself, the intention was to expand all internal rulerefs to other, literal elements.

The problem: If a nesting exists in which a referenced rule references yet another rule, the expansion would be incomplete and inline matching would fail.

This fixes the issue by ensuring that rulerefs continue to be expanded until no more exist.
- [x] Ensure that Rulerefs n-levels deep are expanded
- [x] Improve invalid ruleref error message
- [x] Ensure self-referencial Rules don't cause infinite loops
