### PR TITLE
Rate bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/benlangfeld/ruby_speech)
+  * Feature: Permit percentage rate values for prosody tags
 
 # [2.3.2](https://github.com/benlangfeld/ruby_speech/compare/v2.3.1...v2.3.2) - [2014-04-21](https://rubygems.org/gems/ruby_speech/versions/2.3.2)
   * Bugfix: String nodes should take non-strings and cast to a string (`#to_s`)

--- a/lib/ruby_speech/ssml/prosody.rb
+++ b/lib/ruby_speech/ssml/prosody.rb
@@ -102,27 +102,29 @@ module RubySpeech
       end
 
       ##
-      # A change in the speaking rate for the contained text. Legal values are: a relative change or "x-slow", "slow", "medium", "fast", "x-fast", or "default". Labels "x-slow" through "x-fast" represent a sequence of monotonically non-decreasing speaking rates. When a number is used to specify a relative change it acts as a multiplier of the default rate. For example, a value of 1 means no change in speaking rate, a value of 2 means a speaking rate twice the default rate, and a value of 0.5 means a speaking rate of half the default rate. The default rate for a voice depends on the language and dialect and on the personality of the voice. The default rate for a voice should be such that it is experienced as a normal speaking rate for the voice when reading aloud text. Since voices are processor-specific, the default rate will be as well.
+      # A change in the speaking rate for the contained text. Legal values are: a relative change or "x-slow", "slow", "medium", "fast", "x-fast", or "default". Labels "x-slow" through "x-fast" represent a sequence of monotonically non-decreasing speaking rates. When a number is used to specify a relative change it acts as a multiplier of the default rate. For example, a value of 1 means no change in speaking rate, a value of 2 means a speaking rate twice the default rate, and a value of 0.5 means a speaking rate of half the default rate. Further, changes can be specified as percentages (e.g. '10%' or '+15%'), but these are the only string entries permitted. The default rate for a voice depends on the language and dialect and on the personality of the voice. The default rate for a voice should be such that it is experienced as a normal speaking rate for the voice when reading aloud text. Since voices are processor-specific, the default rate will be as well.
       #
-      # @return [Symbol, Float]
+      # @return [Symbol, Float, String]
       #
       def rate
         value = read_attr :rate
         return unless value
         if VALID_RATES.include?(value.to_sym)
           value.to_sym
+        elsif value.include? "%"
+          value
         else
           value.to_f
         end
       end
 
       ##
-      # @param [Symbol, Numeric] v
+      # @param [Symbol, Numeric, String] v
       #
       # @raises ArgumentError if v is not either a positive Numeric or one of VALID_RATES
       #
       def rate=(v)
-        raise ArgumentError, "You must specify a valid rate ([positive-number](multiplier), #{VALID_RATES.map(&:inspect).join ', '})" unless (v.is_a?(Numeric) && v >= 0) || VALID_RATES.include?(v)
+        raise ArgumentError, "You must specify a valid rate ([positive-number](multiplier), #{VALID_RATES.map(&:inspect).join ', '})" unless (v.is_a?(Numeric) && v >= 0) || VALID_RATES.include?(v) || (v.is_a?(String) && v.include?("%"))
         self[:rate] = v
       end
 

--- a/spec/ruby_speech/ssml/prosody_spec.rb
+++ b/spec/ruby_speech/ssml/prosody_spec.rb
@@ -149,6 +149,24 @@ module RubySpeech
           it "with a negative value" do
             lambda { subject.rate = -100 }.should raise_error(ArgumentError, "You must specify a valid rate ([positive-number](multiplier), :\"x-slow\", :slow, :medium, :fast, :\"x-fast\", :default)")
           end
+
+          describe "with a percentage" do
+            before { subject.rate = "22.5%" }
+
+            its(:rate) { should == "22.5%" }
+          end
+
+          describe "with a percentage and a plus sign" do
+            before { subject.rate = "+22.5%" }
+
+            its(:rate) { should == "+22.5%" }
+          end
+
+          describe "with a percentage and a minus sign" do
+            before { subject.rate = "-22.5%" }
+
+            its(:rate) { should == "-22.5%" }
+          end
         end
       end
 


### PR DESCRIPTION
Adds tests for rate changes that are supplied as a percentage, rather than a decimal multiplier.
Facilitates such rate changes.