### PR TITLE
Fix travis ci suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,39 @@
 language: ruby
 
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby
-  - rbx
-  - ruby-head
 matrix:
+  include:
+    - rvm: 1.9.3
+    - rvm: 2.0.0
+    - rvm: 2.1.0
+    - rvm: 2.2.0
+    - rvm: 2.3.0
+    - rvm: rbx-2
+    - rvm: rbx-3
+    - rvm: ruby-head
+    - rvm: jruby-1.7
+      jdk: openjdk7
+    - rvm: jruby-1.7
+      jdk: oraclejdk7
+    - rvm: jruby-1.7
+      jdk: oraclejdk8
+    - rvm: jruby-head
+      jdk: openjdk7
+    - rvm: jruby-head
+      jdk: oraclejdk7
+    - rvm: jruby-head
+      jdk: oraclejdk8
+    - rvm: jruby-9.0.4.0
+      jdk: openjdk7
+    - rvm: jruby-9.0.4.0
+      jdk: oraclejdk7
+    - rvm: jruby-9.0.4.0
+      jdk: oraclejdk8
   allow_failures:
     - rvm: ruby-head
 before_install:
   - sudo apt-get install libpcre3 libpcre3-dev
   - gem install bundler
+before_script: export JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
 
 notifications:
   irc: "irc.freenode.org#adhearsion"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
     - rvm: jruby-9.0.4.0
       jdk: oraclejdk8
   allow_failures:
+    - rvm: rbx-2
+    - rvm: rbx-3
     - rvm: ruby-head
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,13 @@ matrix:
       jdk: oraclejdk8
   allow_failures:
     - rvm: ruby-head
+sudo: false
+addons:
+  apt:
+    packages:
+    - libpcre3
+    - libpcre3-dev
 before_install:
-  - sudo apt-get install libpcre3 libpcre3-dev
   - gem install bundler
 before_script: export JRUBY_OPTS="--server -J-Xss1024k -J-Xmx652m -J-XX:+UseConcMarkSweepGC"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - rvm: ruby-head
 before_install:
   - sudo apt-get install libpcre3 libpcre3-dev
+  - gem install bundler
 
 notifications:
   irc: "irc.freenode.org#adhearsion"

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<rspec>, ["~> 2.7"]
   s.add_development_dependency %q<ci_reporter>, ["~> 1.6"]
   s.add_development_dependency %q<yard>, [">= 0.7.0"]
-  s.add_development_dependency %q<rake>, [">= 0"]
+  s.add_development_dependency %q<rake>, ["< 11.0"]
   s.add_development_dependency %q<guard>, [">= 0.9.0"]
   s.add_development_dependency %q<guard-rspec>, [">= 0"]
   s.add_development_dependency %q<listen>, ["< 3.1.0"]

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -41,4 +41,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<guard-rake>, [">= 0"]
   s.add_development_dependency %q<rake-compiler>, [">= 0"]
   s.add_development_dependency %q<coveralls>, [">= 0"]
+
+  if RUBY_VERSION < '2.0'
+    s.add_development_dependency %q<term-ansicolor>, ["< 1.3.1"]
+    s.add_development_dependency %q<tins>, ["~> 1.6.0"]
+  end
 end

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<rake>, [">= 0"]
   s.add_development_dependency %q<guard>, [">= 0.9.0"]
   s.add_development_dependency %q<guard-rspec>, [">= 0"]
+  s.add_development_dependency %q<listen>, ["< 3.1.0"]
   s.add_development_dependency %q<ruby_gntp>, [">= 0"]
   s.add_development_dependency %q<guard-rake>, [">= 0"]
   s.add_development_dependency %q<rake-compiler>, [">= 0"]

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency %q<activesupport>, [">= 3.0.7", "< 5.0.0"]
 
   s.add_development_dependency %q<bundler>, [">= 1.0.0"]
-  s.add_development_dependency %q<rspec>, ["~> 2.7"]
+  s.add_development_dependency %q<rspec>, ["~> 2.99.0"]
+  s.add_development_dependency %q<rspec-its>, [">= 0"]
   s.add_development_dependency %q<ci_reporter>, ["~> 1.6"]
   s.add_development_dependency %q<yard>, [">= 0.7.0"]
   s.add_development_dependency %q<rake>, ["< 11.0"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
-require 'ruby_speech'
+# encoding: utf-8
+
+%w{
+  ruby_speech
+  rspec/its
+}.each { |f| require f }
 
 require 'coveralls'
 Coveralls.wear!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 %w{
   ruby_speech


### PR DESCRIPTION
Resolve a number of test-related issues regarding development_dependencies and testing environment setup:

#### Development_dependency fixes:
* [SPEC] Travis-CI: Ensure that coveralls dependencies are still Ruby 1.9 (JRuby 1.7) compatible
  Note: term-ansicolor and tins (sub-dependencies of coveralls) broke SemVer by cutting off ruby 1.9 support apart from a major release
* [SPEC] Travis-CI: Ensure that guard dependencies are still Ruby 1.9 (JRuby 1.7) compatible
  _Similarly, the listen sub-dependency of guard broke SemVer in this regard as well._
* Hold rake back to < 11.0 for rspec-core's sake
  Once we upgrade to rspec 3.0+, we can lift this restriction

#### Environment setup fixes:
* Fix ruby-1.9.3 json dependency issue by using latest stable version of Bundler

#### Other changes:
* Do not allow rspec-2.7 - Our usage of the rspec api was beyond 2.7
* Test more versions of cruby, jruby and Rubinius
* Switch to container environment - not because we have to, but because we can
* Testing all permutations between (jruby-1.7, jruby-9.0.4.0, jruby-head) X (openjdk7, oraclejdk7, oraclejdk8)
  Let me know if this is overkill.

#### Known and expected issues
* All flavors of rubinius are still failing.  Based on the install failures for [rbx-2](https://travis-ci.org/sfgeorge/ruby_speech/jobs/182471553) and [rbx-3](https://travis-ci.org/sfgeorge/ruby_speech/jobs/182471554), this appears to be a _temporary issue_ with unavailability of rubinius binaries or travis's consumption of them.  Note that the following attempts to pull Rubinius as a binary utterly fail during setup:
  * rvm use rbx-2 --install --binary --fuzzy
  * rvm use rbx-3 --install --binary --fuzzy
* Because the Rubinius install issue appears to be temporary, I have not tucked them under the "allow_failures" section, though the temptation to have a fully passing build in the immediate was great.