### PR TITLE
[FIX] Prevent pre-2.1 rubies from failing when trying to install nokogiri 1.7+

### DIFF
--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -27,13 +27,8 @@ Gem::Specification.new do |s|
     s.extensions = ['ext/ruby_speech/extconf.rb']
   end
 
+  s.add_runtime_dependency %q<nokogiri>, ["~> 1.6.0"]
   s.add_runtime_dependency %q<activesupport>, [">= 3.0.7", "< 5.0.0"]
-
-  if RUBY_VERSION < '2.1'
-    s.add_runtime_dependency %q<nokogiri>, ["< 1.7.0"]
-  else
-    s.add_runtime_dependency %q<nokogiri>, ["~> 1.6"]
-  end
 
   s.add_development_dependency %q<bundler>, [">= 1.0.0"]
   s.add_development_dependency %q<rspec>, ["~> 2.99.0"]

--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -27,8 +27,13 @@ Gem::Specification.new do |s|
     s.extensions = ['ext/ruby_speech/extconf.rb']
   end
 
-  s.add_runtime_dependency %q<nokogiri>, ["~> 1.6"]
   s.add_runtime_dependency %q<activesupport>, [">= 3.0.7", "< 5.0.0"]
+
+  if RUBY_VERSION < '2.1'
+    s.add_runtime_dependency %q<nokogiri>, ["< 1.7.0"]
+  else
+    s.add_runtime_dependency %q<nokogiri>, ["~> 1.6"]
+  end
 
   s.add_development_dependency %q<bundler>, [">= 1.0.0"]
   s.add_development_dependency %q<rspec>, ["~> 2.99.0"]


### PR DESCRIPTION
The new Nokogiri 1.7.0 will not install on ruby < 2.1.0

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26