### PR TITLE
[SPEC] Fix code coverage reporting

### DIFF
--- a/ruby_speech.gemspec
+++ b/ruby_speech.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency %q<guard-rake>, [">= 0"]
   s.add_development_dependency %q<rake-compiler>, [">= 0"]
   s.add_development_dependency %q<coveralls>, [">= 0"]
+  s.add_development_dependency %q<simplecov>, [">= 0"]
 
   if RUBY_VERSION < '2.0'
     s.add_development_dependency %q<term-ansicolor>, ["< 1.3.1"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
+require "coveralls"
+Coveralls.wear!
+
 %w{
   rspec/its
-  coveralls
+  ruby_speech
 }.each { |f| require f }
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
-
-Coveralls.wear!
-require "ruby_speech"
 
 schema_file_path = File.expand_path File.join(__FILE__, '../../assets/synthesis.xsd')
 puts "Loading the SSML Schema from #{schema_file_path}..."

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
+Coveralls.wear!
+require "ruby_speech"
+
 schema_file_path = File.expand_path File.join(__FILE__, '../../assets/synthesis.xsd')
 puts "Loading the SSML Schema from #{schema_file_path}..."
 SSML_SCHEMA = Nokogiri::XML::Schema File.open(schema_file_path)
@@ -23,6 +26,3 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
 end
-
-Coveralls.wear!
-require "ruby_speech"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,9 @@
 # frozen_string_literal: true
 
 %w{
-  ruby_speech
   rspec/its
+  coveralls
 }.each { |f| require f }
-
-require 'coveralls'
-Coveralls.wear!
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 
@@ -26,3 +23,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
 end
+
+Coveralls.wear!
+require "ruby_speech"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,13 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require "coveralls"
-Coveralls.wear!
+%w{
+  simplecov
+  coveralls
+}.each { |f| require f }
+
+SimpleCov.formatters << SimpleCov::Formatter::HTMLFormatter
+SimpleCov.start
 
 %w{
   rspec/its


### PR DESCRIPTION
Fix code coverage by ensuring that `Coveralls.wear!` occurs before ruby_speech is loaded.

> Note: The Coveralls.wear! must occur before any of your application code is required, so should be at the very top of your spec_helper.rb, test_helper.rb, or env.rb, etc.

https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails