### PR TITLE
[SPEC] Fix code coverage reporting: Re-enable Coveralls

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,10 @@
   coveralls
 }.each { |f| require f }
 
-SimpleCov.formatters << SimpleCov::Formatter::HTMLFormatter
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
 SimpleCov.start
 
 %w{


### PR DESCRIPTION
Follow-up to #41, this ensures that Coveralls works in tandem with the `coverage/index.html` report produced by SimpleCov-html.